### PR TITLE
chore: add command override for lsp's cargo check

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,22 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#folder-specific-settings
+{
+    "lsp": {
+        "rust-analyzer": {
+            "initialization_options": {
+                "check": {
+                    "overrideCommand": [
+                        "cargo",
+                        "component",
+                        "check",
+                        "--workspace",
+                        "--all-targets",
+                        "--message-format=json"
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This configuration is Zed specific and has already been added for VSCode. It is necessary to add this override as cargo-component needs to be used to check and build WebAssembly components.