### PR TITLE
ci: fix cargo-component binary call

### DIFF
--- a/.github/workflows/test-and-build.yaml
+++ b/.github/workflows/test-and-build.yaml
@@ -191,7 +191,7 @@ jobs:
           fi
 
       - name: Build extensions
-        run: cargo-component build --release --target wasm32-unknown-unknown --workspace --locked
+        run: cargo component build --release --target wasm32-unknown-unknown --workspace --locked
 
       - name: Package extensions
         run: .github/workflows/package.sh


### PR DESCRIPTION
use it as a subcommand to cargo as it may not register the newly installed targets otherwise
