### PR TITLE
ci: remove concurrency field for tests in PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches: ["main"]
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
-
 jobs:
   test:
     name: Test modified extensions


### PR DESCRIPTION
This way actions will not cancel each other when multiple PRs are made and/or changed